### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,6 +5,8 @@ on: [ push, pull_request ]
 jobs:
   test:
     runs-on : ubuntu-latest
+    permissions:
+      contents: read
     steps :
       - name: Checkout
         uses: actions/checkout@v4
@@ -46,6 +48,9 @@ jobs:
     if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' ||  startsWith(github.ref, 'refs/tags/')) }}
     needs: [ test ]
     runs-on : ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/GReD-Clermont/NucleusJ/security/code-scanning/4](https://github.com/GReD-Clermont/NucleusJ/security/code-scanning/4)

To fix the issue, add a `permissions` block at the root level of the workflow or within each job. For this workflow:
1. The `permissions` block should specify only the required access levels for the tasks being performed.
2. For the `test` job, the token likely needs only `contents: read` to access code and repository files.
3. For the `deploy` job, the token may require `contents: read` and `packages: write` for deployment.

The changes will involve adding a `permissions` block to both the `test` and `deploy` jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
